### PR TITLE
refactor(profile): fetch players via /users/:id and /users/by-username

### DIFF
--- a/docs/superpowers/plans/2026-07-24-users-by-username-endpoint.md
+++ b/docs/superpowers/plans/2026-07-24-users-by-username-endpoint.md
@@ -1,0 +1,245 @@
+# Users by-username endpoint Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Keep the DoS-prone `GET /api/users` collection find disabled while restoring every legitimate profile lookup in the web app via scoped single-row endpoints.
+
+**Architecture:** Add one public, IP-rate-limited Strapi endpoint `GET /api/users/by-username/:username` (a mirror of the existing custom `findOne`, keyed on the indexed `username` column). Migrate the web's single `fetchPlayer` consumer to route id-lookups to `GET /api/users/:id` and username-lookups to the new endpoint, and switch `/hesap/edit` to `auth/fetchMe`.
+
+**Tech Stack:** Strapi 5 (TypeScript, users-permissions plugin extension); Nuxt 2 / Vue 2 (JavaScript, Vuex, `$appFetch` Axios wrapper).
+
+## Global Constraints
+
+- Two separate repos/worktrees: backend `parolla-strapi`, frontend `parolla`. No shared build.
+- **No test runner exists** in either repo. Verification = typecheck + lint + targeted runtime checks. Do NOT introduce a test framework.
+- Backend code style: no semicolons, single quotes, trailing commas (es5), 100-char width. Conventional commits (commitlint husky hook).
+- Frontend code style: no semicolons, trailing commas, arrow parens as-needed, max line 150. Conventional commits.
+- The new endpoint's response shape MUST match the existing custom `findOne`: sanitized user + `diceBear`, `profilePhoto`, `role`, `tourScore`. **Never** include `email` on the public by-username endpoint.
+- `plugin.controllers.user.find` MUST remain `ctx.notFound()`. Do not re-enable it.
+- Commit only within each repo; do not attempt cross-repo commits.
+
+---
+
+### Task 1: Backend — `by-username` endpoint + `find` comment + permission hardening
+
+**Repo:** `parolla-strapi`
+
+**Files:**
+- Modify: `src/extensions/users-permissions/strapi-server.ts` (add controller near the existing `findOne` at ~line 124; add route in the `unshift` block near ~line 705; reword the `find` comment at ~line 111)
+- Modify: `config/sync/user-role.public.json` (remove the `plugin::users-permissions.user.find` permission entry)
+- Modify: `config/sync/user-role.authenticated.json` (remove the `plugin::users-permissions.user.find` permission entry)
+
+**Interfaces:**
+- Produces: `GET /api/users/by-username/:username` → `200` single object `{ ...sanitizedUser, diceBear, profilePhoto, role, tourScore }` (no `email`); `404` when username is missing/unknown. Public (`auth: false`), IP-rate-limited.
+- Consumes: existing `getTourScoreDetails(id)` (already imported at top of `strapi-server.ts`) and `sanitizeUserForResponse(user, { includeEmail })` (already imported).
+
+- [ ] **Step 1: Add the `findByUsername` controller**
+
+Immediately after the existing `plugin.controllers.user.findOne` block (~line 150), add:
+
+```ts
+  // by-username controller — public single-user lookup for /profil/:username.
+  // Mirrors findOne but keyed on the indexed `username` column. Single-row
+  // query (no unbounded scan, unlike the disabled collection find). Public,
+  // so email is never exposed here — own-profile editing uses /users/me.
+  plugin.controllers.user.findByUsername = async (ctx) => {
+    const { username } = ctx.params
+
+    if (!username) {
+      return ctx.notFound()
+    }
+
+    const fetched = await strapi.query('plugin::users-permissions.user').findOne({
+      populate: ['diceBear', 'profilePhoto', 'role'],
+      where: { username },
+    })
+
+    if (!fetched) {
+      return ctx.notFound()
+    }
+
+    const tourScoreDetails = await getTourScoreDetails(fetched.id)
+
+    ctx.body = {
+      ...sanitizeUserForResponse(fetched, { includeEmail: false }),
+      tourScore: tourScoreDetails,
+    }
+  }
+```
+
+- [ ] **Step 2: Register the public route**
+
+In the `plugin.routes['content-api'].routes.unshift({...})` block near the end of the file (before `return plugin`), add:
+
+```ts
+  plugin.routes['content-api'].routes.unshift({
+    method: 'GET',
+    path: '/users/by-username/:username',
+    handler: 'user.findByUsername',
+    config: {
+      prefix: '',
+      auth: false,
+      middlewares: [
+        {
+          name: 'global::rate-limit-route',
+          config: { limit: 300, interval: '1h', keyType: 'ip' },
+        },
+      ],
+    },
+  })
+```
+
+- [ ] **Step 3: Reword the `find` disable comment**
+
+The comment above `plugin.controllers.user.find` currently says "No client uses it: individual lookups go through GET /api/users/:id (findOne) and GET /api/users/me, both untouched." Reword the relevant sentence to reflect the added endpoint, e.g.:
+
+```ts
+  // GET /api/users (collection find) is DISABLED. The default plugin action
+  // returns EVERY user row — relations populated, no enforced pagination or
+  // filter — so a single call runs an unbounded query that spikes CPU and
+  // takes the VPS down. Single-user lookups go through GET /api/users/:id
+  // (findOne), GET /api/users/by-username/:username, and GET /api/users/me —
+  // all single-row queries. We hard-refuse the collection find at the
+  // controller so the unbounded query never runs, regardless of role config,
+  // and 404 keeps it effectively hidden.
+```
+
+Leave the body `return ctx.notFound()` unchanged.
+
+- [ ] **Step 4: Remove the `find` permission from the Public role config-sync**
+
+In `config/sync/user-role.public.json`, delete the object whose `action` is
+`"plugin::users-permissions.user.find"` (the `{ documentId, action, locale }` entry).
+Keep `user.findOne` and `user.count`. Ensure the surrounding JSON array stays valid
+(comma handling).
+
+- [ ] **Step 5: Remove the `find` permission from the Authenticated role config-sync**
+
+Do the same in `config/sync/user-role.authenticated.json`: delete the
+`"plugin::users-permissions.user.find"` entry, keep `findOne` / `me` / `count`.
+
+- [ ] **Step 6: Typecheck**
+
+Run: `pnpm typecheck`
+Expected: PASS (no errors). If `findByUsername` triggers a plugin-type error, it is a
+pre-existing pattern issue — the existing `findOne`/`me` custom controllers are assigned
+the same way, so it should type-check identically.
+
+- [ ] **Step 7: Lint**
+
+Run: `pnpm lint`
+Expected: PASS. Fix any style issues (semicolons/quotes) the linter reports on the new code.
+
+- [ ] **Step 8: Runtime check (only if a dev stack is available)**
+
+If Strapi can be started (`pnpm dev` with a DB + env), verify:
+```bash
+# existing username → 200, has diceBear/tourScore, NO email
+curl -s "http://localhost:1337/api/users/by-username/<known-username>" | head -c 400
+# unknown username → 404
+curl -s -o /dev/null -w "%{http_code}\n" "http://localhost:1337/api/users/by-username/__nope__"
+# collection find still disabled → 404
+curl -s -o /dev/null -w "%{http_code}\n" "http://localhost:1337/api/users"
+```
+If no dev stack is available, record this as "not run — requires running Strapi + DB" and rely on typecheck/lint.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/extensions/users-permissions/strapi-server.ts config/sync/user-role.public.json config/sync/user-role.authenticated.json
+git commit -m "feat(users): add public GET /users/by-username/:username; drop find permission"
+```
+
+---
+
+### Task 2: Frontend — migrate `fetchPlayer` and `/hesap/edit`
+
+**Repo:** `parolla`
+
+**Files:**
+- Modify: `store/profile/actions.js:45-63` (`fetchPlayer` action)
+- Modify: `pages/Account/AccountEdit/index.vue:31-35` (`useFetch` body)
+
+**Interfaces:**
+- Consumes: `GET /api/users/:id` (existing findOne) and `GET /api/users/by-username/:username` (Task 1) — both return a single user object (not an array).
+- Produces: `profile/fetchPlayer({ id?, username? })` unchanged signature; commits `SET_PLAYER` with a single object; returns `{ data, error }` where `data` is the object.
+
+- [ ] **Step 1: Rewrite `fetchPlayer` to branch on id/username**
+
+Replace the `fetchPlayer` action body in `store/profile/actions.js` with:
+
+```js
+  async fetchPlayer({ commit }, { id, username }) {
+    const path = id ? `users/${id}` : `users/by-username/${encodeURIComponent(username)}`
+
+    const { data, error } = await this.$appFetch({ path })
+
+    if (data) {
+      commit('SET_PLAYER', data)
+    }
+
+    return {
+      data,
+      error
+    }
+  },
+```
+
+(Removes the old `path: 'users'` + `filters[id|username]` + `populate` query. Both endpoints
+populate diceBear/profilePhoto/role server-side. `data` is now a single object, not `data[0]`.)
+
+- [ ] **Step 2: Switch `/hesap/edit` to refresh `me`**
+
+In `pages/Account/AccountEdit/index.vue`, replace the `useFetch` body:
+
+```js
+    const { fetch, fetchState } = useFetch(async () => {
+      await store.dispatch('auth/fetchMe')
+    })
+```
+
+(Removes the dead `fetchPlayer({ username: me.value.username })` dispatch — `ProfileEditForm`
+reads `auth/user`, not `profile/player`. The `me` computed may become unused; remove it if
+ESLint flags `no-unused-vars`, otherwise leave it.)
+
+- [ ] **Step 3: Confirm no stale collection-find references remain**
+
+Run: `grep -rn "path: 'users'\|path: \`users\`\|filters\[username\]\|filters\[id\]\[\$eq\]" store components pages | grep -v node_modules`
+Expected: no hit that targets the users collection find (the `profile/actions.js` line is now gone).
+
+- [ ] **Step 4: ESLint**
+
+Run: `yarn lint:eslint`
+Expected: PASS. Fix any reported issues (e.g. unused `me` computed in AccountEdit) with `yarn lint:eslint:fix` or manually.
+
+- [ ] **Step 5: Runtime check (only if a dev stack is available)**
+
+If `yarn dev` + a reachable backend are available, verify manually:
+- Open a `/profil/<username>` page → profile loads (network shows `GET /api/users/by-username/<username>`).
+- Click a player avatar / scoreboard row → PlayerDialog loads (network shows `GET /api/users/<id>`).
+- Open `/hesap/edit` while logged in → edit form is populated (network shows `GET /api/users/me`).
+If no dev stack is available, record "not run — requires running web + backend" and rely on ESLint + the grep check.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add store/profile/actions.js pages/Account/AccountEdit/index.vue
+git commit -m "refactor(profile): fetch players via /users/:id and /users/by-username; edit page uses /users/me"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- by-username endpoint (controller + route) → Task 1 Steps 1-2. ✓
+- `find` stays 404 + comment reword → Task 1 Step 3. ✓
+- config-sync permission hardening → Task 1 Steps 4-5. ✓
+- `fetchPlayer` migration (id + username) → Task 2 Step 1. ✓
+- AccountEdit → `me` → Task 2 Step 2. ✓
+- Acceptance criteria (typecheck/lint/runtime) → Task 1 Steps 6-8, Task 2 Steps 4-5. ✓
+- Out-of-scope `updateAvatar` → intentionally untouched. ✓
+
+**Placeholder scan:** No TBD/TODO; all code blocks are concrete. Runtime steps are explicitly conditional on a dev stack, with a defined fallback (record + rely on static gates). ✓
+
+**Type consistency:** `findByUsername` return shape matches `findOne` and matches what `fetchPlayer` consumes (single object). `SET_PLAYER` receives an object in both id and username paths. ✓

--- a/docs/superpowers/specs/2026-07-24-users-by-username-endpoint-design.md
+++ b/docs/superpowers/specs/2026-07-24-users-by-username-endpoint-design.md
@@ -1,0 +1,197 @@
+# Design: Replace public `GET /api/users` (collection find) with a scoped by-username lookup
+
+**Date:** 2026-07-24
+**Repos affected:** `parolla-strapi` (backend), `parolla` (web frontend)
+**Status:** Approved (Approach A)
+
+## Problem
+
+The Strapi users-permissions plugin's collection `find` action (`GET /api/users`) is
+public and applies **no enforced pagination** — the plugin's `find` bypasses
+`config/api.ts` `maxLimit: 100`. A single unfiltered/unpaginated call returns **every
+user row (~50k)** with relations populated, which spikes CPU and takes the VPS down.
+
+A prior change hard-disabled it: `plugin.controllers.user.find` now returns
+`ctx.notFound()`. That stops the DoS but **breaks the one legitimate web consumer**:
+`store/profile/actions.js#fetchPlayer()`, which called
+`GET /api/users?filters[id|username][$eq]=…&populate=diceBear,profilePhoto` and read
+`data[0]`.
+
+The `find → 404` change is **not yet deployed**, so there is no live breakage window —
+backend and web can ship together.
+
+## Verified impact (single root break, three entry points)
+
+`fetchPlayer()` is the **only** web call to the disabled endpoint. Its three call sites:
+
+| Call site | Args | Correct replacement | Already exists? |
+|---|---|---|---|
+| `components/Dialog/PlayerDialog/PlayerDialog.component.vue:71` | `{ id }` | `GET /api/users/:id` (custom `findOne`) | ✅ yes — public, returns diceBear/profilePhoto/role + tourScore |
+| `pages/Profile/_username.vue:53` | `{ username }` | `GET /api/users/by-username/:username` (**new**) | ❌ must add |
+| `pages/Account/AccountEdit/index.vue:33` | `{ username: me.username }` | `GET /api/users/me` / `auth/fetchMe` | ✅ yes |
+
+Confirmed **not** affected (do not touch):
+- `profile/fetchPlayerStats` → `rooms` / `room-scores` / `room-reviews`.
+- `profile/updateAvatar` → `PUT /api/users/:id` (plugin `update`, not `find`).
+- `store/auth/actions.js` → `/users/me`, `/users/me/profile-photo`.
+- `tour/fetchTourScoreOfUser` → `tour-scores/tour-score-of-user` (resolves username server-side; independent).
+- `ProfileEditForm` already reads `auth/user` (i.e. `me`), **not** `profile/player`; the
+  `fetchPlayer` dispatch in `AccountEdit` is effectively dead.
+
+## Design
+
+### 1. Backend — `parolla-strapi`
+
+**File:** `src/extensions/users-permissions/strapi-server.ts`
+
+**a) New controller `user.findByUsername`** — a mirror of the existing custom `findOne`,
+keyed on the (indexed) `username` column instead of `id`. Single-row query. Public
+endpoint, so **never** includes email (own-profile edit goes through `/users/me`).
+
+```ts
+plugin.controllers.user.findByUsername = async (ctx) => {
+  const { username } = ctx.params
+
+  if (!username) {
+    return ctx.notFound()
+  }
+
+  // Single indexed lookup — no unbounded scan (unlike the disabled collection find).
+  const fetched = await strapi.query('plugin::users-permissions.user').findOne({
+    populate: ['diceBear', 'profilePhoto', 'role'],
+    where: { username },
+  })
+
+  if (!fetched) {
+    return ctx.notFound()
+  }
+
+  const tourScoreDetails = await getTourScoreDetails(fetched.id)
+
+  // Public endpoint: email is never exposed here (own-profile editing uses /users/me).
+  ctx.body = {
+    ...sanitizeUserForResponse(fetched, { includeEmail: false }),
+    tourScore: tourScoreDetails,
+  }
+}
+```
+
+Parity note: like the existing `findOne`, this does **not** filter out `isDeleted` users,
+so id- and username-based public lookups behave identically. (Hiding soft-deleted
+profiles, if desired, is a separate follow-up applied to both.)
+
+**b) Register the route** (public, IP rate-limited), alongside the other custom
+`unshift` routes near the end of the file:
+
+```ts
+plugin.routes['content-api'].routes.unshift({
+  method: 'GET',
+  path: '/users/by-username/:username',
+  handler: 'user.findByUsername',
+  config: {
+    prefix: '',
+    auth: false,
+    middlewares: [
+      { name: 'global::rate-limit-route', config: { limit: 300, interval: '1h', keyType: 'ip' } },
+    ],
+  },
+})
+```
+
+Path is two segments so it does not collide with `/users/:id` (findOne) or `/users/me`.
+`auth: false` makes it public with no permission grant required (same pattern as
+`src/api/music/routes/music.ts`), so it never appears as a role checkbox.
+
+**c) `find` stays disabled.** Keep `plugin.controllers.user.find = async (ctx) => ctx.notFound()`.
+Update its comment: the "No client uses it" line becomes true after this migration —
+reword to reference `GET /api/users/:id` and `GET /api/users/by-username/:username` as
+the supported single-user lookups.
+
+**d) Config-sync permission hardening (defense-in-depth).** Remove the
+`plugin::users-permissions.user.find` permission entry from:
+- `config/sync/user-role.public.json`
+- `config/sync/user-role.authenticated.json`
+
+so the endpoint is off at the permission layer too, durably across deploys. (Requires a
+`config-sync import` on deploy, or the equivalent manual uncheck — see Admin panel note.)
+Leave `findOne` and `count` as-is. Do not remove `count` (cheap `SELECT COUNT`, no scan).
+
+### 2. Frontend — `parolla`
+
+**a) `store/profile/actions.js#fetchPlayer`** — keep the `{ id, username }` signature so
+call sites are untouched; branch the path and consume a single object (not `data[0]`):
+
+```js
+async fetchPlayer({ commit }, { id, username }) {
+  const path = id
+    ? `users/${id}`
+    : `users/by-username/${encodeURIComponent(username)}`
+
+  const { data, error } = await this.$appFetch({ path })
+
+  if (data) {
+    commit('SET_PLAYER', data)
+  }
+
+  return { data, error }
+}
+```
+
+Both endpoints always populate diceBear/profilePhoto/role server-side, so the old
+`populate` / `filters` query params are dropped. A missing user now returns `404 → error`
+(instead of an empty array); `pages/Profile/_username.vue` already handles this via
+`playerError` / `playerData?.id`, and `PlayerDialog` via `playerError`.
+
+**b) `pages/Account/AccountEdit/index.vue`** — replace the dead
+`fetchPlayer({ username: me.username })` dispatch with a `me` refresh, since
+`ProfileEditForm` reads `auth/user`:
+
+```js
+const { fetch, fetchState } = useFetch(async () => {
+  await store.dispatch('auth/fetchMe')
+})
+```
+
+**c) Out of scope:** `profile/updateAvatar` (`PUT /api/users/:id`) is unaffected by this
+change. That it is publicly writable is a separate concern (move to `updateMe`) — noted,
+not done here.
+
+### 3. Rollout
+
+No live breakage window (find → 404 not yet deployed):
+1. Ship `parolla-strapi`: `find` = 404 (as-is) **+** new `by-username` route/controller
+   **+** config-sync permission removal. Run `config-sync import` on deploy.
+2. Ship `parolla`: new `fetchPlayer` + AccountEdit change.
+3. **Deploy backend and frontend in the same window.** The `by-username` route is new on
+   the backend, so a split deploy briefly breaks `/profil/:username` (old FE → 403/404 on
+   the removed collection find; new FE → 404 until the route ships). This is a profile-view
+   glitch, not a DoS, and self-heals once both land — but do not rely on "order doesn't
+   matter" for the username path. (The id-path via `findOne` already exists, so PlayerDialog
+   is safe either way.)
+
+## Acceptance criteria
+
+**Backend** (`pnpm typecheck` + `pnpm lint` pass):
+- `GET /api/users/by-username/<existing-username>` → `200`, single sanitized user object
+  with `diceBear`, `profilePhoto`, `role`, `tourScore`; **no `email`**.
+- `GET /api/users/by-username/<nonexistent>` → `404`.
+- `GET /api/users` → `403` for anonymous callers (the `find` permission is removed, so the
+  users-permissions policy denies before the controller) / `404` at the controller if the
+  permission were somehow granted — either way the unbounded query never runs.
+  `GET /api/users/:id` → unchanged. `GET /api/users/me` → unchanged.
+- Route is reachable unauthenticated; repeated calls beyond the IP limit → `429`.
+
+**Frontend** (`yarn lint:eslint` passes):
+- PlayerDialog (avatar/scoreboard click) loads the player via `GET /api/users/:id`.
+- `/profil/:username` loads via `GET /api/users/by-username/:username`; unknown username → empty/error state, no crash.
+- `/hesap/edit` loads the current user via `auth/fetchMe`; edit form is populated.
+- No remaining reference to a collection `filters[username]` / `path: 'users'` find in the web codebase.
+
+## Admin panel note (for the operator)
+
+Because `by-username` uses `auth: false`, it needs **no** role checkbox. The only manual
+action, if not relying on config-sync import, is:
+**Settings → Roles → Public → Users-permissions → User → uncheck `find`.**
+Repeat for the **Authenticated** role. Leave `findOne` and `count` checked. This mirrors
+the config-sync JSON change and is belt-and-suspenders — the controller already returns
+404 for `find` regardless of the permission.

--- a/pages/Account/AccountEdit/index.vue
+++ b/pages/Account/AccountEdit/index.vue
@@ -12,7 +12,7 @@
 </template>
 
 <script>
-import { defineComponent, useStore, useFetch, computed } from '@nuxtjs/composition-api'
+import { defineComponent, useStore, useFetch } from '@nuxtjs/composition-api'
 import { Loading, Empty, Button } from 'vant'
 
 export default defineComponent({
@@ -26,12 +26,8 @@ export default defineComponent({
   setup() {
     const store = useStore()
 
-    const me = computed(() => store.getters['auth/user'])
-
     const { fetch, fetchState } = useFetch(async () => {
-      if (me.value?.username) {
-        await store.dispatch('profile/fetchPlayer', { username: me.value.username })
-      }
+      await store.dispatch('auth/fetchMe')
     })
 
     const reFetch = async () => {

--- a/store/profile/actions.js
+++ b/store/profile/actions.js
@@ -43,21 +43,16 @@ export default {
   },
 
   async fetchPlayer({ commit }, { id, username }) {
-    const { data, error } = await this.$appFetch({
-      path: `users`,
-      query: {
-        'filters[id][$eq]': id,
-        'filters[username][$eq]': username,
-        populate: 'diceBear,profilePhoto'
-      }
-    })
+    const path = id ? `users/${id}` : `users/by-username/${encodeURIComponent(username)}`
+
+    const { data, error } = await this.$appFetch({ path })
 
     if (data) {
-      commit('SET_PLAYER', data[0])
+      commit('SET_PLAYER', data)
     }
 
     return {
-      data: data[0],
+      data,
       error
     }
   },


### PR DESCRIPTION
## Context
The backend collection find `GET /api/users` is being disabled (it returned **all ~50k users** unpaginated and took the VPS down — see selimdoyranli/parolla-strapi#59). This migrates the web's single consumer of that endpoint onto scoped, single-object lookups.

## Change
- **`store/profile/actions.js#fetchPlayer`** now branches the path:
  - `{ id }` → `GET /api/users/:id` (custom `findOne`, already exists)
  - `{ username }` → `GET /api/users/by-username/:username` (new backend endpoint)
  Both return a single user object, so it commits/returns `data` instead of `data[0]`. The `fetchPlayer({ id, username })` **signature is unchanged**, so `PlayerDialog` and the `/profil/:username` page need no edits.
- **`/hesap/edit`** now refreshes the current user via `auth/fetchMe` — `ProfileEditForm` reads `auth/user`, so the old `fetchPlayer({ username: me.username })` dispatch was dead.

## Impact (verified)
Only `fetchPlayer` touched the disabled endpoint. Unaffected: `fetchPlayerStats` (rooms/room-scores/room-reviews), `updateAvatar` (`PUT /users/:id`), `auth` (`/users/me`), `tour/fetchTourScoreOfUser` (`tour-scores/...`). Both mobile shells embed this web app, so they inherit the fix. `role` is now populated on username profiles too (GM badge works there).

## Deploy
Ships **with** selimdoyranli/parolla-strapi#59 in the same window — the `by-username` route is new, so a split deploy briefly 404s `/profil/:username` (profile view only, not a DoS). Design/plan docs included under `docs/superpowers/`.

## Verification
`yarn lint:eslint` clean; no stale `path: 'users'` / `filters[...]` collection-find references remain. End-to-end contract reviewed across both repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
