### PR TITLE
fix(game): match trivia answers exactly without Turkish-to-ASCII folding

### DIFF
--- a/composables/useGameScene.js
+++ b/composables/useGameScene.js
@@ -172,6 +172,13 @@ export default () => {
     return encodeEnglish(value.toLocaleLowerCase('tr').trim().replace(/\s+/g, ''))
   }
 
+  // Trivia answers are exact predefined options, so we must NOT fold Turkish chars to their
+  // ASCII variants (which encodeEnglish does). Otherwise a wrong option like "mahsül" would be
+  // accepted for the correct "mahsul". Only case and whitespace are normalized here.
+  const formatTriviaAnswer = value => {
+    return value.toLocaleLowerCase('tr').trim().replace(/\s+/g, '')
+  }
+
   const handleNotStartsWithActiveChar = ({ activeChar }) => {
     Notify({
       message: i18n.t('gameScene.error.notStartsWithActiveChar', { activeChar }),
@@ -226,7 +233,10 @@ export default () => {
     }
 
     const isCorrect = correctAnswers.some(answer => {
-      if (answerField === encodeEnglish(answer.toLocaleLowerCase('tr').trim().replace(/\s+/g, ''))) {
+      const normalizedAnswer = isTrivia ? formatTriviaAnswer(rawAnswer) : answerField
+      const normalizedCorrect = isTrivia ? formatTriviaAnswer(answer) : formatAnswer(answer)
+
+      if (normalizedAnswer === normalizedCorrect) {
         item.isCorrect = true
         soundFx.correct.play()
 


### PR DESCRIPTION
## Sorun

Trivia quizlerinde sadece 1 şık doğru işaretlenmiş olmasına rağmen, yanlış şık da doğru kabul ediliyordu. Örnek: doğru cevap "mahsul" iken, öbür şıktaki "mahsül" de doğru sayılıyordu.

## Kök neden

`composables/useGameScene.js` içinde tüm oyun modları (Trivia dahil) cevapları `formatAnswer()` → `encodeEnglish()` üzerinden karşılaştırıyordu. `encodeEnglish` Türkçe harfleri ASCII karşılıklarına çeviriyor (`ü→u, ş→s, ı→i, ç→c, ğ→g, ö→o`). Serbest metin modlarında bu esneklik kasıtlı; ama Trivia şıkları birbirinden farklı, önceden tanımlı seçenekler olduğu için bu çeviri iki farklı şıkkı aynı hale getirip yanlış şıkkı doğru kabul ettiriyordu.

## Çözüm

Sadece Trivia için, büyük/küçük harf ve boşlukları normalize eden ama Türkçe harfleri ASCII’ye çevirmeyen `formatTriviaAnswer` eklendi ve doğruluk kontrolü `isTrivia` üzerinden dallandırıldı. Diğer modların (Daily/Unlimited/Tour) mevcut esnek eşleşme davranışı hiç değişmedi. Değişiklik ortak composable’da olduğu için Trivia kullanan tüm modları tek noktadan kapsar.

## Test

- Üretim koddaki formatlayıcıların birebir kopyasıyla yazılan reprodüksiyon scripti: düzeltmeden sonra 5/5 geçti — `mahsül` vs `mahsul` artık **reddediliyor**; doğru şık ve harf/boşluk varyasyonları kabul ediliyor; `Istanbul` (ASCII I) vs `İstanbul` artık ayrı seçenekler olarak değerlendiriliyor.
- `npx eslint composables/useGameScene.js` → exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)